### PR TITLE
Introduce grounded clarification planner and route canonical ambiguity through it

### DIFF
--- a/lib/prompts/query-semantics-extraction.prompt.ts
+++ b/lib/prompts/query-semantics-extraction.prompt.ts
@@ -149,11 +149,18 @@ JSON shape:
   }],
   "clarificationPlan": [{
     "slot": "scope|subject|measure|grain|groupBy|timeRange|assessmentType|aggregatePredicate|entityRef|valueFilter",
+    "reasonCode": "missing_entity|ambiguous_field|ambiguous_value|missing_time_range|missing_measure|missing_grain|missing_assessment_type|unsafe_to_execute",
     "reason": "...",
-    "question": "...",
     "blocking": true,
     "confidence": 0.0,
-    "target": "..."
+    "target": "...",
+    "evidence": {
+      "userPhrase": "...",
+      "matchedConcepts": ["..."],
+      "matchedFields": ["..."],
+      "matchedValues": ["..."],
+      "threadReference": false
+    }
   }],
   "executionRequirements": {
     "requiresPatientResolution": true,
@@ -321,20 +328,30 @@ function normalizeValueSpecs(value: unknown): CanonicalValueSpec[] {
             ? (entry.value as string | null)
             : null,
         resolved: entry.resolved === true,
-      } satisfies CanonicalValueSpec;
+      } as CanonicalValueSpec;
     })
-    .filter((entry): entry is CanonicalValueSpec => Boolean(entry));
+    .filter(Boolean) as CanonicalValueSpec[];
 }
 
 function normalizeClarificationPlan(value: unknown): CanonicalClarificationItem[] {
   if (!Array.isArray(value)) return [];
+  const reasonCodes: CanonicalClarificationItem["reasonCode"][] = [
+    "missing_entity",
+    "ambiguous_field",
+    "ambiguous_value",
+    "missing_time_range",
+    "missing_measure",
+    "missing_grain",
+    "missing_assessment_type",
+    "unsafe_to_execute",
+  ];
   return value
     .map((entry) => {
       if (!isObject(entry)) return null;
       if (
         !CLARIFICATION_SLOTS.includes(entry.slot as ClarificationSlot) ||
         typeof entry.reason !== "string" ||
-        typeof entry.question !== "string" ||
+        !reasonCodes.includes(entry.reasonCode as CanonicalClarificationItem["reasonCode"]) ||
         typeof entry.blocking !== "boolean"
       ) {
         return null;
@@ -342,14 +359,39 @@ function normalizeClarificationPlan(value: unknown): CanonicalClarificationItem[
 
       return {
         slot: entry.slot as CanonicalClarificationItem["slot"],
+        reasonCode: entry.reasonCode as CanonicalClarificationItem["reasonCode"],
         reason: entry.reason,
-        question: entry.question,
+        question: typeof entry.question === "string" ? entry.question : undefined,
         blocking: entry.blocking,
         confidence: clampConfidence(entry.confidence),
         target: typeof entry.target === "string" ? entry.target : undefined,
-      } satisfies CanonicalClarificationItem;
+        evidence: isObject(entry.evidence)
+          ? {
+              userPhrase:
+                typeof entry.evidence.userPhrase === "string"
+                  ? entry.evidence.userPhrase
+                  : undefined,
+              matchedConcepts: Array.isArray(entry.evidence.matchedConcepts)
+                ? entry.evidence.matchedConcepts.filter(
+                    (item): item is string => typeof item === "string"
+                  )
+                : undefined,
+              matchedFields: Array.isArray(entry.evidence.matchedFields)
+                ? entry.evidence.matchedFields.filter(
+                    (item): item is string => typeof item === "string"
+                  )
+                : undefined,
+              matchedValues: Array.isArray(entry.evidence.matchedValues)
+                ? entry.evidence.matchedValues.filter(
+                    (item): item is string => typeof item === "string"
+                  )
+                : undefined,
+              threadReference: entry.evidence.threadReference === true,
+            }
+          : undefined,
+      } as CanonicalClarificationItem;
     })
-    .filter((entry): entry is CanonicalClarificationItem => Boolean(entry));
+    .filter(Boolean) as CanonicalClarificationItem[];
 }
 
 function normalizeExecutionRequirements(value: unknown): ExecutionRequirements {

--- a/lib/services/context-discovery/query-semantics-extractor.service.ts
+++ b/lib/services/context-discovery/query-semantics-extractor.service.ts
@@ -139,6 +139,18 @@ export function deriveCanonicalQuerySemanticsFallback(
     frame?.clarificationNeeds || []
   ).map((need) => ({
     slot: need.slot,
+    reasonCode:
+      need.slot === "measure"
+        ? "missing_measure"
+        : need.slot === "grain" || need.slot === "groupBy"
+          ? "missing_grain"
+          : need.slot === "timeRange"
+            ? "missing_time_range"
+            : need.slot === "assessmentType"
+              ? "missing_assessment_type"
+              : need.slot === "entityRef"
+                ? "missing_entity"
+                : "ambiguous_value",
     reason: need.reason,
     question: need.question,
     blocking: true,

--- a/lib/services/context-discovery/types.ts
+++ b/lib/services/context-discovery/types.ts
@@ -109,11 +109,27 @@ export interface CanonicalValueSpec {
 
 export interface CanonicalClarificationItem {
   slot: ClarificationSlot;
+  reasonCode:
+    | "missing_entity"
+    | "ambiguous_field"
+    | "ambiguous_value"
+    | "missing_time_range"
+    | "missing_measure"
+    | "missing_grain"
+    | "missing_assessment_type"
+    | "unsafe_to_execute";
   reason: string;
-  question: string;
   blocking: boolean;
   confidence: number;
   target?: string;
+  question?: string;
+  evidence?: {
+    userPhrase?: string;
+    matchedConcepts?: string[];
+    matchedFields?: string[];
+    matchedValues?: string[];
+    threadReference?: boolean;
+  };
 }
 
 export interface ExecutionRequirements {

--- a/lib/services/semantic/__tests__/grounded-clarification-planner.service.test.ts
+++ b/lib/services/semantic/__tests__/grounded-clarification-planner.service.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import type { CanonicalQuerySemantics, ContextBundle } from "../../context-discovery/types";
+import { GroundedClarificationPlannerService } from "../grounded-clarification-planner.service";
+
+function buildSemantics(): CanonicalQuerySemantics {
+  return {
+    version: "v1",
+    queryShape: "aggregate",
+    analyticIntent: "operational_metrics",
+    measureSpec: {
+      metrics: ["patient_count"],
+      subject: "patient",
+      grain: "total",
+      groupBy: [],
+      aggregatePredicates: [],
+      presentationIntent: "table",
+      preferredVisualization: "table",
+    },
+    subjectRefs: [],
+    temporalSpec: { kind: "none", rawText: null },
+    valueSpecs: [],
+    clarificationPlan: [
+      {
+        slot: "valueFilter",
+        reasonCode: "ambiguous_value",
+        reason: "Gender mapping is ambiguous",
+        blocking: true,
+        confidence: 0.9,
+        target: "gender",
+        evidence: {
+          userPhrase: "male",
+          matchedFields: ["Gender"],
+          matchedValues: ["Male"],
+        },
+      },
+    ],
+    executionRequirements: {
+      requiresPatientResolution: false,
+      requiredBindings: [],
+      allowSqlGeneration: false,
+      blockReason: "Ambiguous filter",
+    },
+  };
+}
+
+function buildContext(): ContextBundle {
+  return {
+    customerId: "customer-1",
+    question: "how many male patients",
+    intent: {
+      type: "operational_metrics",
+      scope: "aggregate",
+      metrics: ["patient_count"],
+      filters: [],
+      confidence: 0.9,
+      reasoning: "count patients",
+    },
+    forms: [],
+    terminology: [
+      {
+        userTerm: "male",
+        semanticConcept: "gender",
+        fieldName: "Gender",
+        fieldValue: "Male",
+        source: "form_option",
+        confidence: 0.93,
+      },
+    ],
+    joinPaths: [],
+    overallConfidence: 0.8,
+    metadata: {
+      discoveryRunId: "run-1",
+      timestamp: new Date().toISOString(),
+      durationMs: 1,
+      version: "1",
+    },
+  };
+}
+
+describe("GroundedClarificationPlannerService", () => {
+  it("auto-resolves dominant terminology mapping for value filters", () => {
+    const planner = new GroundedClarificationPlannerService();
+    const result = planner.plan({
+      question: "how many male patients",
+      context: buildContext(),
+      canonicalSemantics: buildSemantics(),
+    });
+
+    expect(result.autoResolvedCount).toBe(1);
+    expect(result.clarifications).toEqual([]);
+    expect(result.clarifiedSemantics.executionRequirements.allowSqlGeneration).toBe(
+      true
+    );
+  });
+
+  it("returns grounded options when multiple mappings are present", () => {
+    const planner = new GroundedClarificationPlannerService();
+    const context = buildContext();
+    context.terminology.push({
+      userTerm: "male",
+      semanticConcept: "gender",
+      fieldName: "Gender",
+      fieldValue: "Male",
+      source: "form_option",
+      confidence: 0.84,
+    });
+
+    const result = planner.plan({
+      question: "how many male patients",
+      context,
+      canonicalSemantics: buildSemantics(),
+    });
+
+    expect(result.autoResolvedCount).toBe(0);
+    expect(result.clarifications[0]?.options.length).toBeGreaterThan(0);
+    expect(result.clarifiedSemantics.executionRequirements.allowSqlGeneration).toBe(
+      false
+    );
+  });
+});

--- a/lib/services/semantic/grounded-clarification-planner.service.ts
+++ b/lib/services/semantic/grounded-clarification-planner.service.ts
@@ -1,0 +1,195 @@
+import type { ClarificationRequest } from "@/lib/prompts/generate-query.prompt";
+import type {
+  CanonicalClarificationItem,
+  CanonicalQuerySemantics,
+  ContextBundle,
+  TerminologyMapping,
+} from "../context-discovery/types";
+
+interface PlannerInput {
+  question: string;
+  context: ContextBundle;
+  canonicalSemantics: CanonicalQuerySemantics;
+}
+
+interface PlannerResult {
+  clarifications: ClarificationRequest[];
+  clarifiedSemantics: CanonicalQuerySemantics;
+  autoResolvedCount: number;
+}
+
+function toPlannerOptionId(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+}
+
+function fallbackQuestion(item: CanonicalClarificationItem): string {
+  if (item.question?.trim()) return item.question;
+  return `Please clarify ${item.target || item.slot} so I can run this query safely.`;
+}
+
+function rankMappingsForItem(
+  item: CanonicalClarificationItem,
+  mappings: TerminologyMapping[]
+): TerminologyMapping[] {
+  const evidence = item.evidence;
+  const userPhrase = evidence?.userPhrase?.toLowerCase();
+  const matchedValues = new Set((evidence?.matchedValues || []).map((v) => v.toLowerCase()));
+  const matchedFields = new Set((evidence?.matchedFields || []).map((v) => v.toLowerCase()));
+
+  return mappings
+    .filter((mapping) => {
+      if (userPhrase && mapping.userTerm.toLowerCase() === userPhrase) return true;
+      if (matchedValues.size > 0 && matchedValues.has(mapping.fieldValue.toLowerCase())) return true;
+      if (matchedFields.size > 0 && matchedFields.has(mapping.fieldName.toLowerCase())) return true;
+      return false;
+    })
+    .sort((a, b) => b.confidence - a.confidence);
+}
+
+function hasDominantCandidate(candidates: TerminologyMapping[]): boolean {
+  if (candidates.length === 0) return false;
+  if (candidates.length === 1) return candidates[0].confidence >= 0.8;
+  return (
+    candidates[0].confidence >= 0.85 &&
+    candidates[0].confidence - candidates[1].confidence >= 0.1
+  );
+}
+
+export class GroundedClarificationPlannerService {
+  plan(input: PlannerInput): PlannerResult {
+    const filteredPlan: CanonicalClarificationItem[] = [];
+    const clarifications: ClarificationRequest[] = [];
+    let autoResolvedCount = 0;
+
+    input.canonicalSemantics.clarificationPlan.forEach((item, index) => {
+      if (!item.blocking) {
+        filteredPlan.push(item);
+        return;
+      }
+
+      if (item.slot === "valueFilter") {
+        const candidates = rankMappingsForItem(item, input.context.terminology);
+        if (hasDominantCandidate(candidates)) {
+          autoResolvedCount += 1;
+          return;
+        }
+
+        if (candidates.length > 0) {
+          clarifications.push({
+            id: `grounded_${item.slot}_${index}`,
+            ambiguousTerm: item.target || item.slot,
+            question: fallbackQuestion(item),
+            options: candidates.slice(0, 5).map((candidate, candidateIndex) => ({
+              id: `${toPlannerOptionId(candidate.fieldName)}_${toPlannerOptionId(candidate.fieldValue)}`,
+              label: `${candidate.fieldValue} (${candidate.fieldName})`,
+              sqlConstraint: "",
+              submissionValue: candidate.fieldValue,
+              kind: "semantic",
+              isDefault: candidateIndex === 0 && candidate.confidence >= 0.8,
+              evidence: {
+                confidence: candidate.confidence,
+                fieldName: candidate.fieldName,
+                semanticConcept: candidate.semanticConcept,
+              },
+            })),
+            allowCustom: true,
+            slot: item.slot,
+            target: item.target,
+            reason: item.reason,
+            reasonCode: item.reasonCode,
+            targetType: "value",
+            evidence: {
+              planner: "grounded_clarification_planner",
+              canonicalEvidence: item.evidence || null,
+              source: "terminology_mapping",
+            },
+          });
+          filteredPlan.push(item);
+          return;
+        }
+      }
+
+      if (
+        item.slot === "assessmentType" &&
+        Array.isArray(input.context.assessmentTypes) &&
+        input.context.assessmentTypes.length > 1
+      ) {
+        clarifications.push({
+          id: `grounded_${item.slot}_${index}`,
+          ambiguousTerm: item.target || "assessment type",
+          question: fallbackQuestion(item),
+          options: input.context.assessmentTypes.slice(0, 6).map((assessment, optionIndex) => ({
+            id: `assessment_type_${assessment.assessmentTypeId}`,
+            label: assessment.assessmentName,
+            sqlConstraint: "",
+            submissionValue: assessment.assessmentTypeId,
+            kind: "semantic",
+            isDefault: optionIndex === 0 && assessment.confidence >= 0.8,
+            evidence: {
+              confidence: assessment.confidence,
+              semanticConcept: assessment.semanticConcept,
+            },
+          })),
+          allowCustom: false,
+          slot: item.slot,
+          target: item.target,
+          reason: item.reason,
+          reasonCode: item.reasonCode,
+          targetType: "assessment_type",
+          evidence: {
+            planner: "grounded_clarification_planner",
+            canonicalEvidence: item.evidence || null,
+            source: "assessment_type_search",
+          },
+        });
+        filteredPlan.push(item);
+        return;
+      }
+
+      clarifications.push({
+        id: `grounded_${item.slot}_${index}`,
+        ambiguousTerm: item.target || item.slot,
+        question: fallbackQuestion(item),
+        options: [],
+        allowCustom: true,
+        slot: item.slot,
+        target: item.target,
+        reason: item.reason,
+        reasonCode: item.reasonCode,
+        targetType: "value",
+        evidence: {
+          planner: "grounded_clarification_planner",
+          canonicalEvidence: item.evidence || null,
+          source: "fallback",
+        },
+      });
+      filteredPlan.push(item);
+    });
+
+    const stillBlocked = filteredPlan.some((item) => item.blocking);
+    return {
+      clarifications,
+      autoResolvedCount,
+      clarifiedSemantics: {
+        ...input.canonicalSemantics,
+        clarificationPlan: filteredPlan,
+        executionRequirements: {
+          ...input.canonicalSemantics.executionRequirements,
+          allowSqlGeneration: stillBlocked ? false : true,
+          blockReason: stillBlocked
+            ? input.canonicalSemantics.executionRequirements.blockReason
+            : undefined,
+        },
+      },
+    };
+  }
+}
+
+let plannerSingleton: GroundedClarificationPlannerService | null = null;
+
+export function getGroundedClarificationPlannerService(): GroundedClarificationPlannerService {
+  if (!plannerSingleton) {
+    plannerSingleton = new GroundedClarificationPlannerService();
+  }
+  return plannerSingleton;
+}

--- a/lib/services/semantic/three-mode-orchestrator.service.ts
+++ b/lib/services/semantic/three-mode-orchestrator.service.ts
@@ -91,6 +91,7 @@ import {
   getSemanticExecutionDiagnosticsService,
   type SemanticExecutionDiagnostics,
 } from "./semantic-execution-diagnostics.service";
+import { getGroundedClarificationPlannerService } from "./grounded-clarification-planner.service";
 
 export type QueryMode = "template" | "direct" | "funnel" | "clarification";
 
@@ -1503,6 +1504,50 @@ export class ThreeModeOrchestrator {
         context.canonicalSemantics.executionRequirements.allowSqlGeneration === false &&
         !clarifications
       ) {
+        const groundedPlanner = getGroundedClarificationPlannerService();
+        const groundedPlan = groundedPlanner.plan({
+          question,
+          context,
+          canonicalSemantics: context.canonicalSemantics,
+        });
+        context.canonicalSemantics = groundedPlan.clarifiedSemantics;
+
+        if (
+          context.canonicalSemantics.executionRequirements.allowSqlGeneration !== false
+        ) {
+          console.log(
+            "[Orchestrator] ✅ Canonical ambiguity auto-resolved by grounded clarification planner",
+            { autoResolvedCount: groundedPlan.autoResolvedCount }
+          );
+        } else if (groundedPlan.clarifications.length > 0) {
+          contextDiscoveryStep.status = "complete";
+          contextDiscoveryStep.duration = Date.now() - discoveryStart;
+          contextDiscoveryStep.message = "Semantic clarification required";
+          return {
+            mode: "clarification",
+            question,
+            thinking,
+            requiresClarification: true,
+            clarifications: groundedPlan.clarifications,
+            clarificationReasoning:
+              context.canonicalSemantics.executionRequirements.blockReason ||
+              "Additional clarification is needed before SQL generation.",
+            context: {
+              canonicalSemantics: context.canonicalSemantics,
+              canonicalSemanticsVersion: context.canonicalSemantics.version,
+            },
+            canonicalSemantics: context.canonicalSemantics,
+          };
+        }
+
+      }
+
+      if (
+        useCanonicalSemantics &&
+        context.canonicalSemantics &&
+        context.canonicalSemantics.executionRequirements.allowSqlGeneration === false &&
+        !clarifications
+      ) {
         contextDiscoveryStep.status = "complete";
         contextDiscoveryStep.duration = Date.now() - discoveryStart;
         contextDiscoveryStep.message = "Semantic clarification required";
@@ -2572,7 +2617,9 @@ export class ThreeModeOrchestrator {
         .map((item, index) => ({
           id: `canonical_${item.slot}_${index}`,
           ambiguousTerm: item.target || item.slot,
-          question: item.question,
+          question:
+            item.question ||
+            `Please clarify ${item.target || item.slot} to continue.`,
           options: [],
           allowCustom: true,
           slot: item.slot,

--- a/lib/utils/__tests__/canonical-thread-patient-merge.test.ts
+++ b/lib/utils/__tests__/canonical-thread-patient-merge.test.ts
@@ -24,6 +24,7 @@ const baseSemantics = (): CanonicalQuerySemantics => ({
   clarificationPlan: [
     {
       slot: "entityRef",
+      reasonCode: "missing_entity",
       reason: "No named patient in the message",
       question: "Which patient do you want to analyze?",
       blocking: true,


### PR DESCRIPTION
### Motivation
- Prevent canonical semantics from directly producing freeform-only clarifications by splitting ambiguity detection from UX grounding.
- Auto-resolve high-confidence, common mappings (e.g., gender terms) and prefer concrete option lists over freeform only as the default.

### Description
- Added a new `GroundedClarificationPlannerService` that synthesizes user-facing clarifications from `CanonicalQuerySemantics`, attempts dominant auto-resolution for `valueFilter`, and produces optionized requests for `valueFilter` and `assessmentType` when appropriate (`lib/services/semantic/grounded-clarification-planner.service.ts`).
- Updated the orchestrator to route canonical blocking ambiguity through the grounded planner first and only return a clarification response if the planner cannot auto-resolve or optionize (`lib/services/semantic/three-mode-orchestrator.service.ts`).
- Enriched canonical clarification contract by adding `reasonCode` and optional `evidence`, and made `question` optional to keep canonical semantics structural (`lib/services/context-discovery/types.ts`).
- Extended prompt/normalization and fallback semantics to parse/emit the new structural clarification shape and populate `reasonCode` for fallback items (`lib/prompts/query-semantics-extraction.prompt.ts`, `lib/services/context-discovery/query-semantics-extractor.service.ts`).
- Small UX/fallback tweak so canonical-style clarifications include a sensible fallback question when `question` is not present, and updated the canonical-thread-patient-merge test fixture accordingly.
- Added unit tests for the planner behavior covering auto-resolution and multi-candidate option generation (`lib/services/semantic/__tests__/grounded-clarification-planner.service.test.ts`) and adjusted an existing test to match the enriched clarification shape (`lib/utils/__tests__/canonical-thread-patient-merge.test.ts`).

### Testing
- Ran the planner and merge unit tests with `pnpm -s vitest run lib/services/semantic/__tests__/grounded-clarification-planner.service.test.ts lib/utils/__tests__/canonical-thread-patient-merge.test.ts`, and all tests passed (4 tests total).
- Ran `pnpm -s vitest run` for the affected test files individually during development; planner behaviors validated (auto-resolve and optionization scenarios).
- Ran `pnpm -s tsc --noEmit` and observed many pre-existing unrelated TypeScript errors in the repository; these failures are not introduced by this change set and did not block the targeted unit tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cc9563ebd88327885e8ba57132a88e)